### PR TITLE
Rails flavored ruby

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+
+  # ()内の、page_title= は、デフォルト値である
+  def full_title(page_title='')
+    base_title = "Ruby on Rails Tutorial Sample App"
+    if page_title.empty?
+      base_title
+    else
+      page_title + " | " + base_title
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>
-      <%= yield(:title) %> | Ruby on Rails Tutorial Sample App
-    </title>
+    <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, "Home") %>
+<%# <% provide(:title, "Home") %>
 
 <h1>StaticPages#home</h1>
 <p>

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -2,36 +2,36 @@ require 'test_helper'
 
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
   def setup
-    @base_title = " | Ruby on Rails Tutorial Sample App"
+    @base_title = "Ruby on Rails Tutorial Sample App"
   end
 
   test "should get root" do
     get root_url
     assert_response :success
-    assert_select "title", "Home#{@base_title}"
+    assert_select "title", "#{@base_title}"
   end
 
   test "should get home" do
     get static_pages_home_url
     assert_response :success
-    assert_select "title", "Home#{@base_title}"
+    assert_select "title", "#{@base_title}"
   end
 
   test "should get help" do
     get static_pages_help_url
     assert_response :success
-    assert_select "title", "Help#{@base_title}"
+    assert_select "title", "Help | #{@base_title}"
   end
 
   test "should get about" do
     get static_pages_about_url
     assert_response :success
-    assert_select "title", "About#{@base_title}"
+    assert_select "title", "About | #{@base_title}"
   end
 
   test "should get contact" do
     get static_pages_contact_url
     assert_response :success
-    assert_select "title", "Contact#{@base_title}"
+    assert_select "title", "Contact | #{@base_title}"
   end
 end


### PR DESCRIPTION
## Why
- <title>を動的に作成するページを作成

## What
- application_helperにて、タイトルがない場合はデフォルトのタイトルが表示される処理を行っている